### PR TITLE
fix bug for tinyint(8) unsigned

### DIFF
--- a/data/view/cnf/def.go
+++ b/data/view/cnf/def.go
@@ -43,9 +43,14 @@ var TypeMysqlDicMp = map[string]string{
 }
 
 // TypeMysqlMatchMp Fuzzy Matching Types.模糊匹配类型
+
+// TypeMysqlMatchMp Fuzzy Matching Types.模糊匹配类型
 var TypeMysqlMatchMp = map[string]string{
-	`^(tinyint)[(]\d+[)]`:            "int8",
 	`^(tinyint)[(]\d+[)] unsigned`:   "uint8",
+	`^(smallint)[(]\d+[)] unsigned`:  "uint16",
+	`^(int)[(]\d+[)] unsigned`:       "uint32",
+	`^(bigint)[(]\d+[)] unsigned`:    "uint64",
+	`^(tinyint)[(]\d+[)]`:            "int8",
 	`^(smallint)[(]\d+[)]`:           "int16",
 	`^(int)[(]\d+[)]`:                "int",
 	`^(bigint)[(]\d+[)]`:             "int64",


### PR DESCRIPTION
When I used this tool to generate files, I found that even if the table structure did not change, the generated files would change. After debugging. Finding the configuration here will cause the program to find two keys randomly. The original code might have tinyint (8) unsigned randomly match int8 or Unit8. Put the unsigned one to the front, and then test it. This problem will not happen again.