### PR TITLE
feat:通过使用--table_prefix 给表名加前缀

### DIFF
--- a/data/view/genfunc/def.go
+++ b/data/view/genfunc/def.go
@@ -122,12 +122,12 @@ func {{$obj.StructName}}Mgr(db *gorm.DB) *_{{$obj.StructName}}Mgr {
 		panic(fmt.Errorf("{{$obj.StructName}}Mgr need init by db"))
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	return &_{{$obj.StructName}}Mgr{_BaseMgr: &_BaseMgr{DB: db.Table("{{$obj.TableName}}"), isRelated: globalIsRelated,ctx:ctx,cancel:cancel,timeout:-1}}
+	return &_{{$obj.StructName}}Mgr{_BaseMgr: &_BaseMgr{DB: db.Table("{{GetTablePrefixName $obj.TableName}}"), isRelated: globalIsRelated,ctx:ctx,cancel:cancel,timeout:-1}}
 }
 
 // GetTableName get sql table name.获取数据库名字
 func (obj *_{{$obj.StructName}}Mgr) GetTableName() string {
-	return "{{$obj.TableName}}"
+	return "{{GetTablePrefixName $obj.TableName}}"
 }
 
 // Get 获取

--- a/data/view/model/common.go
+++ b/data/view/model/common.go
@@ -47,6 +47,17 @@ func CapLowercase(name string) string { // IDAPIID == > idAPIID
 	return FilterKeywords(re)
 }
 
+// GetTablePrefixName 获取带表前缀名字的tablename
+func GetTablePrefixName(name string) string { //
+	tablePrefix := config.GetTablePrefix()
+	//如果设置了表前缀
+	if tablePrefix != "" {
+		return fmt.Sprintf("%v.%v", tablePrefix, name)
+	}
+
+	return name
+}
+
 func FilterKeywords(src string) string {
 	if tools.IsKeywords(src) {
 		return "_" + src

--- a/data/view/model/model.go
+++ b/data/view/model/model.go
@@ -48,7 +48,7 @@ func (m *_Model) GetPackage() genstruct.GenPackage {
 		var pkg genstruct.GenPackage
 		pkg.SetPackage(m.info.PackageName) //package name
 
-		tablePrefix := config.GetTablePrefix()
+		// tablePrefix := config.GetTablePrefix()
 
 		for _, tab := range m.info.TabList {
 			var sct genstruct.GenStruct
@@ -56,9 +56,9 @@ func (m *_Model) GetPackage() genstruct.GenPackage {
 			sct.SetTableName(tab.Name)
 
 			//如果设置了表前缀
-			if tablePrefix != "" {
-				tab.Name = strings.TrimLeft(tab.Name, tablePrefix)
-			}
+			// if tablePrefix != "" {
+			// 	tab.Name = strings.TrimLeft(tab.Name, tablePrefix)
+			// }
 
 			sct.SetStructName(getCamelName(tab.Name)) // Big hump.大驼峰
 			sct.SetNotes(tab.Notes)
@@ -257,11 +257,11 @@ func (m *_Model) generateFunc() (genOut []GenOutInfo) {
 		// wxw 2021.2.26 17:17
 		var data funDef
 		data.TableName = tab.Name
-		tablePrefix := config.GetTablePrefix()
-		//如果设置了表前缀
-		if tablePrefix != "" {
-			tab.Name = strings.TrimLeft(tab.Name, tablePrefix)
-		}
+		// tablePrefix := config.GetTablePrefix()
+		// //如果设置了表前缀
+		// if tablePrefix != "" {
+		// 	tab.Name = strings.TrimLeft(tab.Name, tablePrefix)
+		// }
 		data.StructName = getCamelName(tab.Name)
 
 		var primary, unique, uniqueIndex, index []FList
@@ -335,7 +335,7 @@ func (m *_Model) generateFunc() (genOut []GenOutInfo) {
 		data.Primay = append(data.Primay, uniqueIndex...)
 		data.Index = append(data.Index, index...)
 		tmpl, err := template.New("gen_logic").
-			Funcs(template.FuncMap{"GenPreloadList": GenPreloadList, "GenFListIndex": GenFListIndex, "CapLowercase": CapLowercase}).
+			Funcs(template.FuncMap{"GenPreloadList": GenPreloadList, "GenFListIndex": GenFListIndex, "CapLowercase": CapLowercase, "GetTablePrefixName": GetTablePrefixName}).
 			Parse(genfunc.GetGenLogicTemp())
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
使得：
func (obj *_SymbolMgr) GetTableName() string {
 return "symbol"
}
变成：
func (obj *_SymbolMgr) GetTableName() string {
 return "tableprefix.symbol"
}
并在源头确定表名:tableprefix.symbol.
即真正执行mysql语句的时候，会按照tableprefix.symbol这个表名去执行。