### PR TITLE
fix 存在 index:sort 时候和  gorm 本身 sort 标签冲突导致的错误

### DIFF
--- a/data/view/model/model.go
+++ b/data/view/model/model.go
@@ -134,11 +134,15 @@ func (m *_Model) genTableElement(cols []ColumnsInfo) (el []genstruct.GenElement)
 					case ColumnsKeyUnique: // unique key.唯一索引
 						tmp.AddTag(_tagGorm, "unique")
 					case ColumnsKeyIndex: // index key.复合索引
-						if v1.KeyType == "FULLTEXT" {
-							tmp.AddTag(_tagGorm, getUninStr("index", ":", v1.KeyName)+",class:FULLTEXT")
-						} else {
-							tmp.AddTag(_tagGorm, getUninStr("index", ":", v1.KeyName))
+						uninStr := getUninStr("index", ":", v1.KeyName)
+						// 兼容 gorm 本身 sort 标签
+						if v1.KeyName == "sort" {
+							uninStr = "index"
 						}
+						if v1.KeyType == "FULLTEXT" {
+							uninStr += ",class:FULLTEXT"
+						}
+						tmp.AddTag(_tagGorm, uninStr)
 					case ColumnsKeyUniqueIndex: // unique index key.唯一复合索引
 						tmp.AddTag(_tagGorm, getUninStr("uniqueIndex", ":", v1.KeyName))
 					}


### PR DESCRIPTION
table:

```
CREATE TABLE `menu` (
  `id` mediumint NOT NULL AUTO_INCREMENT COMMENT 'ID',
  `sort` mediumint NOT NULL COMMENT '排序',
  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
  PRIMARY KEY (`id`) USING BTREE,
  KEY `sort` (`sort`) USING BTREE
) ENGINE=InnoDB AUTO_INCREMENT=158 DEFAULT CHARSET=utf8 COMMENT='menu table';

```
model struct :

```
type Menu struct {
	ID int32     `gorm:"primaryKey;column:id;type:mediumint;not null" json:"-"`
	Sort                 int32     `gorm:"index:sort;column:sort;type:mediumint;not null" json:"sort"`  
	CreateTime           time.Time `gorm:"column:create_time;type:timestamp;default:CURRENT_TIMESTAMP" json:"createTime"` 
}
```


run db.AutoMigrate(&Menu{}) 

get error:

**Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL 
server version for the right syntax to use near 'SORT))' at line 1**

get sql:
```
CREATE TABLE `menus` (`id` mediumint NOT NULL,`sort` mediumint NOT NULL,`create_time` timestamp DEFAULT CURRENT_TIMESTAMP,PRIMARY KEY (`id`),INDEX sort (`sort` SORT))  
```
