### PR TITLE
Fix field name camelcase bug

### DIFF
--- a/data/view/model/common.go
+++ b/data/view/model/common.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/xxjwxc/public/mybigcamel"
+	"github.com/xxjwxc/public/tools"
+
 	"github.com/xxjwxc/gormt/data/config"
 	"github.com/xxjwxc/gormt/data/view/cnf"
 	"github.com/xxjwxc/gormt/data/view/genfunc"
-	"github.com/xxjwxc/public/mybigcamel"
-	"github.com/xxjwxc/public/tools"
 )
 
 // getCamelName Big Hump or Capital Letter.大驼峰或者首字母大写
@@ -20,7 +21,7 @@ func getCamelName(name string) string {
 	// 	return mybigcamel.Marshal(strings.TrimSuffix(name, "s"))
 	// }
 
-	return mybigcamel.Marshal(name)
+	return CamelCase(name)
 }
 
 // titleCase title case.首字母大写

--- a/data/view/model/name.go
+++ b/data/view/model/name.go
@@ -1,0 +1,119 @@
+package model
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// commonInitialisms is a set of common initialisms.
+// source: https://github.com/golang/lint/blob/master/lint.go
+var commonInitialisms = map[string]bool{
+	"ACL":   true,
+	"API":   true,
+	"ASCII": true,
+	"CPU":   true,
+	"CSS":   true,
+	"DNS":   true,
+	"EOF":   true,
+	"GUID":  true,
+	"HTML":  true,
+	"HTTP":  true,
+	"HTTPS": true,
+	"ID":    true,
+	"IP":    true,
+	"JSON":  true,
+	"LHS":   true,
+	"QPS":   true,
+	"RAM":   true,
+	"RHS":   true,
+	"RPC":   true,
+	"SLA":   true,
+	"SMTP":  true,
+	"SQL":   true,
+	"SSH":   true,
+	"TCP":   true,
+	"TLS":   true,
+	"TTL":   true,
+	"UDP":   true,
+	"UI":    true,
+	"UID":   true,
+	"UUID":  true,
+	"URI":   true,
+	"URL":   true,
+	"UTF8":  true,
+	"VM":    true,
+	"XML":   true,
+	"XMPP":  true,
+	"XSRF":  true,
+	"XSS":   true,
+}
+
+// CamelCase converts field name to pretty struct attribute name
+func CamelCase(fieldName string) string {
+	var b bytes.Buffer
+
+	var words []string
+
+	var i int
+	for s := fieldName; s != ""; s = s[i:] { // split on upper letter or _
+		i = strings.IndexFunc(s[1:], unicode.IsUpper) + 1
+		if i <= 0 {
+			i = len(s)
+		}
+		word := s[:i]
+		words = append(words, strings.Split(word, "_")...)
+	}
+
+	// words := strings.Split(fieldName, "_")
+	for i, word := range words {
+		if u := strings.ToUpper(word); commonInitialisms[u] {
+			b.WriteString(u)
+			continue
+		}
+
+		word = removeInvalidChars(word, i == 0) // on 0 remove first digits
+		if len(word) == 0 {
+			continue
+		}
+
+		out := strings.ToUpper(string(word[0]))
+		if len(word) > 1 {
+			out += strings.ToLower(word[1:])
+		}
+		b.WriteString(out)
+	}
+
+	if b.Len() == 0 { // check if this is number
+		if _, err := strconv.Atoi(fieldName); err == nil {
+			b.WriteString("Key")
+			b.WriteString(fieldName)
+		}
+	}
+
+	return b.String()
+}
+
+func removeInvalidChars(s string, removeFirstDigit bool) string {
+	var buf bytes.Buffer
+
+	for _, b := range []byte(s) {
+		if b >= 97 && b <= 122 { // a-z
+			buf.WriteByte(b)
+			continue
+		}
+		if b >= 65 && b <= 90 { // A-Z
+			buf.WriteByte(b)
+			continue
+		}
+		if b >= 48 && b <= 57 { // 0-9
+			if !removeFirstDigit || buf.Len() > 0 {
+				buf.WriteByte(b)
+				continue
+			}
+		}
+	}
+
+	return buf.String()
+}

--- a/data/view/model/name.go
+++ b/data/view/model/name.go
@@ -52,12 +52,11 @@ var commonInitialisms = map[string]bool{
 
 // CamelCase converts field name to pretty struct attribute name
 func CamelCase(fieldName string) string {
-	var b bytes.Buffer
+	var b strings.Builder
 
 	var words []string
 
-	var i int
-	for s := fieldName; s != ""; s = s[i:] { // split on upper letter or _
+	for i, s := 0, fieldName; s != ""; s = s[i:] { // split on upper letter or _
 		i = strings.IndexFunc(s[1:], unicode.IsUpper) + 1
 		if i <= 0 {
 			i = len(s)
@@ -66,7 +65,6 @@ func CamelCase(fieldName string) string {
 		words = append(words, strings.Split(word, "_")...)
 	}
 
-	// words := strings.Split(fieldName, "_")
 	for i, word := range words {
 		if u := strings.ToUpper(word); commonInitialisms[u] {
 			b.WriteString(u)

--- a/data/view/model/names_test.go
+++ b/data/view/model/names_test.go
@@ -1,0 +1,90 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNames(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		fieldName    string
+		expectedName string
+	}{
+		{
+			name:         "simple lowercase",
+			fieldName:    "name",
+			expectedName: "Name",
+		},
+		{
+			name:         "snake case",
+			fieldName:    "field_name",
+			expectedName: "FieldName",
+		},
+		{
+			name:         "long snake",
+			fieldName:    "field__name",
+			expectedName: "FieldName",
+		},
+		{
+			name:         "snake at ends",
+			fieldName:    "_field_name_",
+			expectedName: "FieldName",
+		},
+		{
+			name:         "long snake at ends",
+			fieldName:    "__field_name",
+			expectedName: "FieldName",
+		},
+		{
+			name:         "snake case with initialism",
+			fieldName:    "html_field_name",
+			expectedName: "HTMLFieldName",
+		},
+		{
+			name:         "camel case",
+			fieldName:    "camelCaseName",
+			expectedName: "CamelCaseName",
+		},
+		{
+			name:         "mixed case",
+			fieldName:    "mixed_caseName_test",
+			expectedName: "MixedCaseNameTest",
+		},
+		{
+			name:         "mixed case with initialism",
+			fieldName:    "mixed_caseName_htmlTest",
+			expectedName: "MixedCaseNameHTMLTest",
+		},
+		{
+			name:         "special chars",
+			fieldName:    "$field_$name日本語",
+			expectedName: "FieldName",
+		},
+		{
+			name:         "garbage",
+			fieldName:    "$@!%^&*()",
+			expectedName: "",
+		},
+		{
+			name:         "starting with digits",
+			fieldName:    "123key",
+			expectedName: "Key",
+		},
+		{
+			name:         "name with digits",
+			fieldName:    "key_666",
+			expectedName: "Key666",
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedName, CamelCase(tc.fieldName))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/spf13/cobra v1.0.0
+	github.com/stretchr/testify v1.7.0
 	github.com/xxjwxc/public v0.0.0-20210611023445-d5fd9e893ee4
 	golang.org/x/text v0.3.3
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
修复字段名字不符号golint规范. 比如我的数据库是`uid`,竟然给我转成`UId`,其实应该是`UID`, PR修复问题.