### PR TITLE
修复了当表字段类型为datetime或者time并且默认为NULL时，在结构中没有被设置成指针类型的问题

### DIFF
--- a/data/view/model/common.go
+++ b/data/view/model/common.go
@@ -100,6 +100,9 @@ func fixNullToPorint(name string, isNull bool) string {
 		if strings.HasPrefix(name, "float") {
 			return "*" + name
 		}
+		if strings.HasPrefix(name, "time") {
+			return "*" + name
+		}
 	}
 
 	return name


### PR DESCRIPTION
数据库默认 'DEFAULT NULL' 时设置结构为指针类型只支持了uint、int、float等这几个类型，但是并未提供对time类型的支持，导致time.Time字段默认为NULL时，也没有在结构中被设置成指针类型