### PR TITLE
增加了对分页查询的支持

### DIFF
--- a/data/view/genfunc/def.go
+++ b/data/view/genfunc/def.go
@@ -257,6 +257,30 @@ func (obj *_{{$obj.StructName}}Mgr) GetByOptions(opts ...Option) (results []*{{$
 	{{GenPreloadList $obj.PreloadList true}}
 	return
 }
+
+// SelectPage 分页查询
+func (obj *_{{$obj.StructName}}Mgr) SelectPage(page IPage,opts ...Option) (resultPage IPage, err error) {
+	options := options{
+		query: make(map[string]interface{}, len(opts)),
+	}
+	for _, o := range opts {
+		o.apply(&options)
+	}
+	resultPage = page
+	results := make([]{{$obj.StructName}},0)
+	var count int64 // 统计总的记录数
+	query :=  obj.DB.WithContext(obj.ctx).Model({{$obj.StructName}}{}).Where(options.query)
+	query.Count(&count)
+	resultPage.SetTotal(count)
+	if len(page.GetOrederItemsString()) > 0 {
+		query = query.Order(page.GetOrederItemsString())
+	}
+	err = query.Limit(int(page.GetSize())).Offset(int(page.Offset())).Find(&results).Error
+	{{GenPreloadList $obj.PreloadList true}}
+	resultPage.SetRecords(results)
+	return
+}
+
 //////////////////////////enume case ////////////////////////////////////////////
 
 {{range $oem := $obj.Em}}
@@ -326,4 +350,145 @@ func (obj *_{{$obj.StructName}}Mgr) GetBatchFrom{{$oem.ColStructName}}({{CapLowe
 			} {{end}} {{end}}
 	}
 }`
+genPage = `package {{.PackageName}}
+
+import (
+	"fmt"
+	"strings"
+)
+
+type IPage interface {
+	GetRecords() interface{}      // 获取查询的记录
+	SetRecords(interface{})       // 设置查询的记录
+	GetTotal() int64              // 获取总记录数
+	SetTotal(int64)               // 设置总记录数
+	GetCurrent() int64            // 获取当前页
+	SetCurrent(int64)             // 设置当前页
+	GetSize() int64               // 获取每页显示大小
+	SetSize(int64)                // 设置每页显示大小
+	AddOrderItem(OrderItem)       // 设置排序条件
+	AddOrderItems([]OrderItem)    // 批量设置排序条件
+	GetOrederItemsString() string // 将排序条件拼接成字符串
+	Offset() int64                // 获取偏移量
+	GetPages() int64              // 获取总的分页数
+}
+
+type Page struct {
+	total   int64       // 总的记录数
+	size    int64       // 每页显示的大小
+	current int64       // 当前页
+	orders  []OrderItem // 排序条件
+	Records interface{} // 查询数据列表
+
+}
+
+func (page *Page) GetRecords() interface{} {
+	return page.Records
+}
+
+func (page *Page) SetRecords(records interface{}) {
+	page.Records = records
+}
+
+func (page *Page) GetTotal() int64 {
+	return page.total
+}
+
+func (page *Page) SetTotal(total int64) {
+	page.total = total
+
+}
+
+func (page *Page) GetCurrent() int64 {
+	return page.current
+}
+
+func (page *Page) SetCurrent(current int64) {
+	page.current = current
+}
+
+func (page *Page) GetSize() int64 {
+	return page.size
+}
+func (page *Page) SetSize(size int64) {
+	page.size = size
+
+}
+
+func (page *Page) AddOrderItem(orderItem OrderItem) {
+	page.orders = append(page.orders, orderItem)
+}
+
+func (page *Page) AddOrderItems(orderItems []OrderItem) {
+	page.orders = append(page.orders, orderItems...)
+}
+
+func (page *Page) GetOrederItemsString() string {
+	arr := make([]string, 0)
+	var order string
+
+	for _, val := range page.orders {
+		if val.asc {
+			order = ""
+		} else {
+			order = "desc"
+		}
+		arr = append(arr, fmt.Sprintf("%s %s", val.column, order))
+	}
+	return strings.Join(arr, ",")
+}
+
+func (page *Page) Offset() int64 {
+	if page.GetCurrent() > 0 {
+		return (page.GetCurrent() - 1) * page.GetSize()
+	} else {
+		return 0
+	}
+}
+
+func (page *Page) GetPages() int64 {
+	if page.GetSize() == 0 {
+		return 0
+	}
+	pages := page.GetTotal() / page.GetSize()
+	if page.GetTotal()%page.size != 0 {
+		pages++
+	}
+
+	return pages
+}
+
+type OrderItem struct {
+	column string // 需要排序的字段
+	asc    bool   // 是否正序排列，默认true
+}
+
+func BuildAsc(column string) OrderItem {
+	return OrderItem{column: column, asc: true}
+}
+
+func BuildDesc(column string) OrderItem {
+	return OrderItem{column: column, asc: false}
+}
+
+func BuildAscs(columns ...string) []OrderItem {
+	items := make([]OrderItem, 0)
+	for _, val := range columns {
+		items = append(items, BuildAsc(val))
+	}
+	return items
+}
+
+func BuildDescs(columns ...string) []OrderItem {
+	items := make([]OrderItem, 0)
+	for _, val := range columns {
+		items = append(items, BuildDesc(val))
+	}
+	return items
+}
+
+func NewPage(size, current int64, orderItems ...OrderItem) *Page {
+	return &Page{size: size, current: current, orders: orderItems}
+}
+`
 )

--- a/data/view/genfunc/genfunc.go
+++ b/data/view/genfunc/genfunc.go
@@ -27,3 +27,7 @@ func GetGenPreloadTemp(multi bool) string {
 	}
 	return genPreload
 }
+
+func GetGenPageTemp() string {
+	return genPage
+}

--- a/data/view/model/common.go
+++ b/data/view/model/common.go
@@ -103,6 +103,12 @@ func fixNullToPorint(name string, isNull bool) string {
 		if strings.HasPrefix(name, "time") {
 			return "*" + name
 		}
+		if strings.HasPrefix(name, "bool") {
+			return "*" + name
+		}
+		if strings.HasPrefix(name, "string") {
+			return "*" + name
+		}
 	}
 
 	return name

--- a/data/view/model/model.go
+++ b/data/view/model/model.go
@@ -323,6 +323,22 @@ func (m *_Model) generateFunc() (genOut []GenOutInfo) {
 	//tools.WriteFile(outDir+"gen_router.go", []string{buf.String()}, true)
 	// -------end------
 
+	// gen page 分页查询的基础
+	genPage, err := template.New("gen_page").Parse(genfunc.GetGenPageTemp())
+	if err != nil {
+		panic(err)
+	}
+
+	var bufPage bytes.Buffer
+	genPage.Execute(&bufPage, m.info)
+	genOut = append(genOut, GenOutInfo{
+		FileName: "gen.page.go",
+		FileCtx:  bufPage.String(),
+	})
+
+	// -------end------
+
+
 	for _, tab := range m.info.TabList {
 		var pkg genstruct.GenPackage
 		pkg.SetPackage(m.info.PackageName) //package name


### PR DESCRIPTION
# 一、增加分页查询支持
参照myabtis-plus中的分页查询插件，封装了一个分页查询函数。可以通过传入一个IPage的分页接口,通过指定的排序字段以及查询条件等纪念性分页查询，获得总记录数，分页数，查询记录等信息。具体可以查看`data/view/genfunc/def.go`文件中的`genPage`。

以下代码是简单的使用案例，测试使用的数据为`data/view/genfunc/model/matrix.sql`
```go
func TestSelectPage(t *testing.T) {
	model.OpenRelated() // 打开全局预加载 (外键)

	db := GetGorm("root:123456@tcp(192.168.253.100:3306)/gormt?charset=utf8&parseTime=True&loc=Local&interpolateParams=True")
	defer func() {
		sqldb, _ := db.DB()
		sqldb.Close()
	}()

	accountMgr := model.AccountMgr(db)
	// 构造分页条件
	page := model.NewPage(1, 1)
	// 不带条件的查询
	result, err := accountMgr.SelectPage(page)
	fmt.Println("不带条件查询")
	fmt.Println(err)
	fmt.Println(result.GetPages())
	fmt.Println(result.GetTotal())
	for _, val := range result.GetRecords().([]model.Account) {
		fmt.Println(val)
	}

	//带条件查询
	page = model.NewPage(1, 2)
	result, err = accountMgr.SelectPage(page, accountMgr.WithName("bbbb"))
	fmt.Println("带条件查询")
	fmt.Println(err)
	fmt.Println(result.GetPages())
	fmt.Println(result.GetTotal())
	for _, val := range result.GetRecords().([]model.Account) {
		fmt.Println(val)
	}

	// 进行排序，按name字段降序
	page = model.NewPage(1, 1, model.BuildDesc("name"))
	result, err = accountMgr.SelectPage(page)
	fmt.Println("进行排序，按name字段降序")
	fmt.Println(err)
	fmt.Println(result.GetPages())
	fmt.Println(result.GetTotal())
	for _, val := range result.GetRecords().([]model.Account) {
		fmt.Println(val)
	}
}
```

# 二、修复bool和string类型变量默认为空时，在结构中没有被设置为指针