### PR TITLE
完善分页开关

### DIFF
--- a/data/view/genfunc/def.go
+++ b/data/view/genfunc/def.go
@@ -258,6 +258,7 @@ func (obj *_{{$obj.StructName}}Mgr) GetByOptions(opts ...Option) (results []*{{$
 	return
 }
 
+{{if $obj.IsOutPage}}
 // SelectPage 分页查询
 func (obj *_{{$obj.StructName}}Mgr) SelectPage(page IPage,opts ...Option) (resultPage IPage, err error) {
 	options := options{
@@ -280,6 +281,7 @@ func (obj *_{{$obj.StructName}}Mgr) SelectPage(page IPage,opts ...Option) (resul
 	resultPage.SetRecords(results)
 	return
 }
+{{end}}
 
 //////////////////////////enume case ////////////////////////////////////////////
 
@@ -350,7 +352,7 @@ func (obj *_{{$obj.StructName}}Mgr) GetBatchFrom{{$oem.ColStructName}}({{CapLowe
 			} {{end}} {{end}}
 	}
 }`
-genPage = `package {{.PackageName}}
+	genPage = `package {{.PackageName}}
 
 import (
 	"fmt"

--- a/data/view/model/def.go
+++ b/data/view/model/def.go
@@ -117,6 +117,7 @@ type funDef struct {
 	Em          []EmInfo      // index 列表
 	Primary     []FList       // primary unique
 	Index       []FList       // index
+	IsOutPage   bool		  // 是否开启分页
 }
 
 //

--- a/data/view/model/model.go
+++ b/data/view/model/model.go
@@ -349,6 +349,7 @@ func (m *_Model) generateFunc() (genOut []GenOutInfo) {
 		// wxw 2021.2.26 17:17
 		var data funDef
 		data.TableName = tab.Name
+		data.IsOutPage = config.GetIsOutPage() // 添加分页开关
 		tab.Name = getTableNameWithPrefix(tab.Name)
 
 		data.StructName = getCamelName(tab.Name)


### PR DESCRIPTION
如果关闭生成分页函数的话，`data/view/genfunc/def.go`中的`SelectPage`也应该关闭，因为这个函数依赖`gen.page.go`中的IPage，如果关闭的时候还生成了这个函数，会导致报错