### PR TITLE
Update common.go

### DIFF
--- a/data/view/model/common.go
+++ b/data/view/model/common.go
@@ -100,6 +100,9 @@ func fixNullToPorint(name string, isNull bool) string {
 		if strings.HasPrefix(name, "float") {
 			return "*" + name
 		}
+		if strings.HasPrefix(name, "date") {
+			return "*" + name
+		}
 		if strings.HasPrefix(name, "time") {
 			return "*" + name
 		}


### PR DESCRIPTION
当表字段类型为datetime或者date并且默认为NULL时，在结构中需要设置成指针类型