### PR TITLE
给自定义SQL增加了根据条件判断是否生成的功能

### DIFF
--- a/data/view/genfunc/def.go
+++ b/data/view/genfunc/def.go
@@ -117,31 +117,45 @@ func CloseRelated() {
 
 
 // 自定义sql查询
-type Condition struct {
-	list []*conditionInfo
+type Query struct {
+	list []*queryInfo
 }
 
-// And a condition by and .and 一个条件
-func (c *Condition) And(column string, cases string, value interface{}) {
-	c.list = append(c.list, &conditionInfo{
-		andor:  "and",
-		column: column, // 列名
-		case_:  cases,  // 条件(and,or,in,>=,<=)
-		value:  value,
-	})
+func (c *Query) AndOnCondition(condition bool,column string, cases string, value interface{}) {
+	if condition {
+		c.list = append(c.list, &queryInfo{
+			andor:  "and",
+			column: column, // 列名
+			case_:  cases,  // 条件(and,or,in,>=,<=)
+			value:  value,
+		})
+	}
 }
 
-// Or a condition by or .or 一个条件
-func (c *Condition) Or(column string, cases string, value interface{}) {
-	c.list = append(c.list, &conditionInfo{
-		andor:  "or",
-		column: column, // 列名
-		case_:  cases,  // 条件(and,or,in,>=,<=)
-		value:  value,
-	})
+
+// And a Condition by and .and 一个条件
+func (c *Query) And(column string, cases string, value interface{}) {
+	c.AndOnCondition(true,column,cases,value)
 }
 
-func (c *Condition) Get() (where string, out []interface{}) {
+
+func (c *Query) OrOnCondition(condition bool,column string, cases string, value interface{}) {
+	if condition {
+		c.list = append(c.list, &queryInfo{
+			andor:  "or",
+			column: column, // 列名
+			case_:  cases,  // 条件(and,or,in,>=,<=)
+			value:  value,
+		})
+	}
+}
+
+// Or a Condition by or .or 一个条件
+func (c *Query) Or(column string, cases string, value interface{}) {
+	c.OrOnCondition(true,column,cases,value)
+}
+
+func (c *Query) Get() (where string, out []interface{}) {
 	firstAnd := -1
 	for i := 0; i < len(c.list); i++ { // 查找第一个and
 		if c.list[i].andor == "and" {
@@ -168,7 +182,7 @@ func (c *Condition) Get() (where string, out []interface{}) {
 	return
 }
 
-type conditionInfo struct {
+type queryInfo struct {
 	andor  string
 	column string // 列名
 	case_  string // 条件(in,>=,<=)

--- a/data/view/genfunc/def.go
+++ b/data/view/genfunc/def.go
@@ -117,45 +117,47 @@ func CloseRelated() {
 
 
 // 自定义sql查询
-type Query struct {
-	list []*queryInfo
+type Condition struct {
+	list []*conditionInfo
 }
 
-func (c *Query) AndOnCondition(condition bool,column string, cases string, value interface{}) {
+func (c *Condition) AndWithCondition(condition bool,column string, cases string, value interface{}) (*Condition) {
 	if condition {
-		c.list = append(c.list, &queryInfo{
+		c.list = append(c.list, &conditionInfo{
 			andor:  "and",
 			column: column, // 列名
 			case_:  cases,  // 条件(and,or,in,>=,<=)
 			value:  value,
 		})
 	}
+	return c
 }
 
 
 // And a Condition by and .and 一个条件
-func (c *Query) And(column string, cases string, value interface{}) {
-	c.AndOnCondition(true,column,cases,value)
+func (c *Condition) And(column string, cases string, value interface{}) (*Condition) {
+	return c.AndWithCondition(true,column,cases,value)
 }
 
 
-func (c *Query) OrOnCondition(condition bool,column string, cases string, value interface{}) {
+func (c *Condition) OrWithCondition(condition bool,column string, cases string, value interface{}) (*Condition)  {
 	if condition {
-		c.list = append(c.list, &queryInfo{
+		c.list = append(c.list, &conditionInfo{
 			andor:  "or",
 			column: column, // 列名
 			case_:  cases,  // 条件(and,or,in,>=,<=)
 			value:  value,
 		})
 	}
+	return c
 }
 
 // Or a Condition by or .or 一个条件
-func (c *Query) Or(column string, cases string, value interface{}) {
-	c.OrOnCondition(true,column,cases,value)
+func (c *Condition) Or(column string, cases string, value interface{}) (*Condition) {
+	return c.OrWithCondition(true,column,cases,value)
 }
 
-func (c *Query) Get() (where string, out []interface{}) {
+func (c *Condition) Get() (where string, out []interface{}) {
 	firstAnd := -1
 	for i := 0; i < len(c.list); i++ { // 查找第一个and
 		if c.list[i].andor == "and" {
@@ -182,7 +184,7 @@ func (c *Query) Get() (where string, out []interface{}) {
 	return
 }
 
-type queryInfo struct {
+type conditionInfo struct {
 	andor  string
 	column string // 列名
 	case_  string // 条件(in,>=,<=)

--- a/data/view/genfunc/genfunc_test.go
+++ b/data/view/genfunc/genfunc_test.go
@@ -140,12 +140,13 @@ func TestFuncFetchBy(t *testing.T) {
 
 // TestCondition 测试sql构建
 func TestCondition(t *testing.T) {
-	condition := model.Condition{}
-	condition.And(model.AccountColumns.AccountID, ">=", "1")
-	condition.And(model.AccountColumns.UserID, "in", []string{"1", "2", "3"})
-	condition.Or(model.AccountColumns.Type, "in", []string{"1", "2", "3"})
+	query := model.Query{}
+	query.And(model.AccountColumns.AccountID, ">=", "1")
+	query.And(model.AccountColumns.UserID, "in", []string{"1", "2", "3"})
+	query.AndOnCondition(false, model.AccountColumns.AccountID, "in", []string{"5"})
+	query.Or(model.AccountColumns.Type, "in", []string{"1", "2", "3"})
 
-	where, obj := condition.Get()
+	where, obj := query.Get()
 	fmt.Println(where)
 	fmt.Println(obj...)
 
@@ -155,6 +156,6 @@ func TestCondition(t *testing.T) {
 		sqldb.Close()
 	}()
 
-	accountMgr := model.AccountMgr(db.Where(condition.Get()))
+	accountMgr := model.AccountMgr(db.Where(where, obj))
 	accountMgr.Gets()
 }

--- a/data/view/genfunc/genfunc_test.go
+++ b/data/view/genfunc/genfunc_test.go
@@ -156,6 +156,6 @@ func TestCondition(t *testing.T) {
 		sqldb.Close()
 	}()
 
-	accountMgr := model.AccountMgr(db.Where(where, obj))
+	accountMgr := model.AccountMgr(db.Where(where, obj...))
 	accountMgr.Gets()
 }

--- a/data/view/genfunc/genfunc_test.go
+++ b/data/view/genfunc/genfunc_test.go
@@ -140,13 +140,13 @@ func TestFuncFetchBy(t *testing.T) {
 
 // TestCondition 测试sql构建
 func TestCondition(t *testing.T) {
-	query := model.Query{}
-	query.And(model.AccountColumns.AccountID, ">=", "1")
-	query.And(model.AccountColumns.UserID, "in", []string{"1", "2", "3"})
-	query.AndOnCondition(false, model.AccountColumns.AccountID, "in", []string{"5"})
-	query.Or(model.AccountColumns.Type, "in", []string{"1", "2", "3"})
+	condition := model.Condition{}
+	condition.And(model.AccountColumns.AccountID, ">=", "1")
+	condition.And(model.AccountColumns.UserID, "in", []string{"1", "2", "3"})
+	condition.AndWithCondition(false, model.AccountColumns.AccountID, "in", []string{"5"})
+	condition.Or(model.AccountColumns.Type, "in", []string{"1", "2", "3"})
 
-	where, obj := query.Get()
+	where, obj := condition.Get()
 	fmt.Println(where)
 	fmt.Println(obj...)
 

--- a/data/view/genfunc/model/gen.base.go
+++ b/data/view/genfunc/model/gen.base.go
@@ -93,43 +93,45 @@ func CloseRelated() {
 }
 
 // 自定义sql查询
-type Query struct {
-	list []*queryInfo
+type Condition struct {
+	list []*conditionInfo
 }
 
-func (c *Query) AndOnCondition(condition bool, column string, cases string, value interface{}) {
+func (c *Condition) AndWithCondition(condition bool, column string, cases string, value interface{}) (*Condition) {
 	if condition {
-		c.list = append(c.list, &queryInfo{
+		c.list = append(c.list, &conditionInfo{
 			andor:  "and",
 			column: column, // 列名
 			case_:  cases,  // 条件(and,or,in,>=,<=)
 			value:  value,
 		})
 	}
+	return c
 }
 
 // And a Condition by and .and 一个条件
-func (c *Query) And(column string, cases string, value interface{}) {
-	c.AndOnCondition(true, column, cases, value)
+func (c *Condition) And(column string, cases string, value interface{})(*Condition) {
+	return c.AndWithCondition(true, column, cases, value)
 }
 
-func (c *Query) OrOnCondition(condition bool, column string, cases string, value interface{}) {
+func (c *Condition) OrWithCondition(condition bool, column string, cases string, value interface{}) (*Condition){
 	if condition {
-		c.list = append(c.list, &queryInfo{
+		c.list = append(c.list, &conditionInfo{
 			andor:  "or",
 			column: column, // 列名
 			case_:  cases,  // 条件(and,or,in,>=,<=)
 			value:  value,
 		})
 	}
+	return c
 }
 
 // Or a Condition by or .or 一个条件
-func (c *Query) Or(column string, cases string, value interface{}) {
-	c.OrOnCondition(true, column, cases, value)
+func (c *Condition) Or(column string, cases string, value interface{})(*Condition) {
+	return c.OrWithCondition(true, column, cases, value)
 }
 
-func (c *Query) Get() (where string, out []interface{}) {
+func (c *Condition) Get() (where string, out []interface{}) {
 	firstAnd := -1
 	for i := 0; i < len(c.list); i++ { // 查找第一个and
 		if c.list[i].andor == "and" {
@@ -156,7 +158,7 @@ func (c *Query) Get() (where string, out []interface{}) {
 	return
 }
 
-type queryInfo struct {
+type conditionInfo struct {
 	andor  string
 	column string // 列名
 	case_  string // 条件(in,>=,<=)

--- a/data/view/genfunc/model/gen.base.go
+++ b/data/view/genfunc/model/gen.base.go
@@ -93,31 +93,43 @@ func CloseRelated() {
 }
 
 // 自定义sql查询
-type Condition struct {
-	list []*conditionInfo
+type Query struct {
+	list []*queryInfo
 }
 
-// And a condition by and .and 一个条件
-func (c *Condition) And(column string, cases string, value interface{}) {
-	c.list = append(c.list, &conditionInfo{
-		andor:  "and",
-		column: column, // 列名
-		case_:  cases,  // 条件(and,or,in,>=,<=)
-		value:  value,
-	})
+func (c *Query) AndOnCondition(condition bool, column string, cases string, value interface{}) {
+	if condition {
+		c.list = append(c.list, &queryInfo{
+			andor:  "and",
+			column: column, // 列名
+			case_:  cases,  // 条件(and,or,in,>=,<=)
+			value:  value,
+		})
+	}
 }
 
-// Or a condition by or .or 一个条件
-func (c *Condition) Or(column string, cases string, value interface{}) {
-	c.list = append(c.list, &conditionInfo{
-		andor:  "or",
-		column: column, // 列名
-		case_:  cases,  // 条件(and,or,in,>=,<=)
-		value:  value,
-	})
+// And a Condition by and .and 一个条件
+func (c *Query) And(column string, cases string, value interface{}) {
+	c.AndOnCondition(true, column, cases, value)
 }
 
-func (c *Condition) Get() (where string, out []interface{}) {
+func (c *Query) OrOnCondition(condition bool, column string, cases string, value interface{}) {
+	if condition {
+		c.list = append(c.list, &queryInfo{
+			andor:  "or",
+			column: column, // 列名
+			case_:  cases,  // 条件(and,or,in,>=,<=)
+			value:  value,
+		})
+	}
+}
+
+// Or a Condition by or .or 一个条件
+func (c *Query) Or(column string, cases string, value interface{}) {
+	c.OrOnCondition(true, column, cases, value)
+}
+
+func (c *Query) Get() (where string, out []interface{}) {
 	firstAnd := -1
 	for i := 0; i < len(c.list); i++ { // 查找第一个and
 		if c.list[i].andor == "and" {
@@ -144,7 +156,7 @@ func (c *Condition) Get() (where string, out []interface{}) {
 	return
 }
 
-type conditionInfo struct {
+type queryInfo struct {
 	andor  string
 	column string // 列名
 	case_  string // 条件(in,>=,<=)


### PR DESCRIPTION
给自定义SQL增加了根据条件判断是否生成的功能。因为有时候在查询时，某些字段需要根据前端传过来的查询参数来决定是否需要，例如对文章标题或者内容字段进行查找时，只有当前端传递过来的title这个字段不为空时才需要添加。使用类似下列情况
```go
query := model.Query{}
query.AndOnCondition(vo.GetTitle()!= nil,"title","=",vo.GetTitle())
query.And("username", "=", "name1")
```
像下面这个生成的sql为
```go
query := model.Query{}
query.And("username", "=", "name1")
query.OrOnCondition(false, "password", "=", "pwd1")
fmt.Println(query.Get())
```
```
`username` = ? [name1]
```
在使用自定义SQL时，直接把`Get()`的返回值当作参数传给`db.Where()` 会出现下列问题，所有的参数都只会被放到第一个变量里面而已。
```sql
SELECT * FROM `blog_admin` WHERE `username` = ('name1','pwd1') or `password` = ?
```
所以应该接受`Get()`的返回值后，再分别传入
```go
accountMgr := model.AccountMgr(db.Where(where, obj))
```
