### PR TITLE
当字段默认值为NULL，并且结构不设置为指针时，添加default:null的tag

### DIFF
--- a/data/view/model/model.go
+++ b/data/view/model/model.go
@@ -184,7 +184,10 @@ func (m *_Model) genTableElement(cols []ColumnsInfo) (el []genstruct.GenElement)
 					tmp.AddTag(_tagGorm, "type:"+v.Type)
 					if !v.IsNull {
 						tmp.AddTag(_tagGorm, "not null")
-					}
+					} else if v.IsNull && !config.GetIsNullToPoint() {
+						// 当该字段默认值为null，并且结构不用指针类型时，添加default:null的tag
+						tmp.AddTag(_tagGorm,"default:null")
+					}					
 					// default tag
 					if len(v.Gormt) > 0 {
 						tmp.AddTag(_tagGorm, v.Gormt)


### PR DESCRIPTION
当字段默认值为NULL，并且结构不设置为指针时，如果没有添加default:null的tag，在新增和一切其他操作时，会出错。因为在这个字段上会加上默认的0值。