### PR TITLE
增加把default null类型字段设置为sql.NullXXX类型

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,6 +16,7 @@ is_gui : false # 是否ui模式显示
 is_table_name : true # 是否直接生成表名
 is_column_name : true # 是否直接生成列名
 is_null_to_point : false # 数据库默认 'DEFAULT NULL' 时设置结构为指针类型
+is_null_to_sql_null: false # 数据库默认 'DEFAULT NULL' 时设置结构为sql.NULL  is_null_to_point如果为true，则is_null_to_sql_null不生效
 table_prefix : "" # 表前缀, 如果有则使用, 没有留空(如果表前缀以"-"开头，则表示去掉该前缀，struct、文件名都会去掉该前缀)
 table_names: "" # 指定表生成，多个表用,隔开
 is_out_file_by_table_name: false # 是否根据表名生成多个model

--- a/data/config/MyIni.go
+++ b/data/config/MyIni.go
@@ -25,7 +25,8 @@ type Config struct {
 	IsGUI                bool              `yaml:"is_gui"` //
 	IsTableName          bool              `yaml:"is_table_name"`
 	IsNullToPoint        bool              `yaml:"is_null_to_point"` // null to porint
-	TablePrefix          string            `yaml:"table_prefix"`     // 表前缀
+	IsNullToSqlNull      bool              `yaml:"is_null_to_sql_null"`
+	TablePrefix          string            `yaml:"table_prefix"` // 表前缀
 	SelfTypeDef          map[string]string `yaml:"self_type_define"`
 	OutFileName          string            `yaml:"out_file_name"`
 	WebTagType           int               `yaml:"web_tag_type"`              // 默认小驼峰
@@ -224,6 +225,14 @@ func SetIsNullToPoint(b bool) {
 // GetIsNullToPoint get if with null to porint in sturct
 func GetIsNullToPoint() bool {
 	return _map.IsNullToPoint
+}
+
+func SetIsNullToSqlNull(b bool) {
+	_map.IsNullToSqlNull = b
+}
+
+func GetIsNullToSqlNull() bool {
+	return _map.IsNullToSqlNull
 }
 
 // SetTablePrefix set table prefix

--- a/data/view/model/common.go
+++ b/data/view/model/common.go
@@ -113,6 +113,30 @@ func fixNullToPorint(name string, isNull bool) string {
 			return "*" + name
 		}
 	}
+	if isNull && config.GetIsNullToSqlNull() {
+
+		if strings.HasPrefix(name, "uint") {
+			return "sql.NullInt64"
+		}
+		if strings.HasPrefix(name, "int") {
+			return "sql.NullInt32"
+		}
+		if strings.HasPrefix(name, "float") {
+			return "sql.NullFloat64"
+		}
+		if strings.HasPrefix(name, "date") {
+			return "sql.NullTime"
+		}
+		if strings.HasPrefix(name, "time") {
+			return "sql.NullTime"
+		}
+		if strings.HasPrefix(name, "bool") {
+			return "sql.NullBool"
+		}
+		if strings.HasPrefix(name, "string") {
+			return "sql.NullString"
+		}
+	}
 
 	return name
 }


### PR DESCRIPTION
实现了把默认DEFAULT NULL的字段用sql.NullXXX表示，可以通过is_null_to_sql_null参数来进行控制，但is_null_to_sql_null设置为true时生效。不过如果is_null_to_point 也为true的话，is_null_to_sql_null不生效。