### PR TITLE
使用fieldalignment工具实现struct内存对齐，节省内存空间

### DIFF
--- a/data/view/gtools/gtools.go
+++ b/data/view/gtools/gtools.go
@@ -57,8 +57,12 @@ func showCmd() {
 		path := config.GetOutDir() + "/" + v.FileName
 		tools.WriteFile(path, []string{v.FileCtx}, true)
 
+		mylog.Info("fix structure fields for memory alignment")
+		cmd, _ := exec.Command("fieldalignment", "-fix", path).Output()
+		mylog.Info(string(cmd))
+
 		mylog.Info("formatting differs from goimport's:")
-		cmd, _ := exec.Command("goimports", "-l", "-w", path).Output()
+		cmd, _ = exec.Command("goimports", "-l", "-w", path).Output()
 		mylog.Info(string(cmd))
 
 		mylog.Info("formatting differs from gofmt's:")


### PR DESCRIPTION
使用fieldalignment工具实现struct内存对齐，节省内存空间
首先需要本地下载fieldalignment， `go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest`
效果如下
```go
type Admin struct {
	NickName string
	Age      int
	Name     string
}
```
fieldalignment -fix .（最后一个参数可以是路径或者是一个具体的文件）
```go
type Admin struct {
	NickName string
	Name     string
	Age      int
}
```

![image](https://user-images.githubusercontent.com/44432198/214593863-3de5ab93-33bb-4fd2-b29a-4b57add4cc87.png)
