### PR TITLE
打包发版，发布到 https://pkg.go.dev/github.com/xxjwxc/gormt@v1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ## install
 
 ```
-go get -u -v github.com/xxjwxc/gormt@master
+go get -u -v github.com/xxjwxc/gormt@latest
 ```
 
 or: [Dowloading](https://github.com/xxjwxc/gormt/releases)


### PR DESCRIPTION
# 不能正常导包
```
go get -u -v gethub.com/xxjwxc/grom@master
````
目前pkg官网只有三个版本，都不能用，坏掉了

<img width="566" alt="image" src="https://user-images.githubusercontent.com/31272102/236140119-99a77278-976f-4b10-a078-06387e7cb171.png">

# 三个版本都坏掉了

<img width="1448" alt="image" src="https://user-images.githubusercontent.com/31272102/236140421-4c809482-3660-461a-b250-47a6420b91e5.png">

不能调用重新打包发版一下

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/31272102/236141698-a8e5f9f7-a006-43a4-b02b-0dae1d0a6a46.png">

<img width="704" alt="image" src="https://user-images.githubusercontent.com/31272102/236141843-012b8fb8-fc98-4ed4-8c60-05f91dadb06c.png">


# 麻烦重新打包一下`tag`标签，以规范的格式打包，才能被`pkg`收录，影响使用

